### PR TITLE
Add careers API

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/node": "^22.5.5",
     "@types/nodemailer": "^7.0.1",
     "@types/nunjucks": "^3.2.6",
+    "@types/pg": "^8.15.5",
     "@typescript-eslint/eslint-plugin": "^8.6.0",
     "@typescript-eslint/parser": "^8.6.0",
     "cross-env": "^10.0.0",

--- a/src/routes/careers/index.ts
+++ b/src/routes/careers/index.ts
@@ -1,0 +1,49 @@
+import { JsonSchemaToTsProvider } from '@fastify/type-provider-json-schema-to-ts'
+import { JSONSchema } from 'json-schema-to-ts'
+import { FastifyPluginAsync } from 'fastify'
+
+const routesPlugin: FastifyPluginAsync = async function routesPlugin (fastify) {
+  const server = fastify.withTypeProvider<JsonSchemaToTsProvider>()
+
+  const careerResponseSchema = {
+    type: 'object',
+    properties: {
+      id: { type: 'integer' },
+      name: { type: 'string' },
+      slug: { type: 'string' },
+      createdAt: { type: 'string', format: 'date-time' },
+      updatedAt: { type: 'string', format: 'date-time' }
+    },
+    required: ['id', 'name', 'slug', 'createdAt', 'updatedAt']
+  } as const satisfies JSONSchema
+
+  server.route({
+    method: 'GET',
+    url: '/',
+    schema: {
+      description: 'Get all careers',
+      tags: ['Careers'],
+      response: {
+        200: {
+          type: 'array',
+          items: careerResponseSchema
+        } as const satisfies JSONSchema
+      }
+    },
+    async handler (request, reply) {
+      const services = request.server.services
+      const careers = await services.careerService().findAll()
+
+      const records = careers.map(career => ({
+        ...career,
+        createdAt: career.createdAt.toISOString(),
+        updatedAt: career.updatedAt.toISOString()
+      }))
+
+      await reply.status(200).send(records)
+    }
+  })
+}
+
+export default routesPlugin
+

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,8 +1,10 @@
 import fp from 'fastify-plugin'
 import userRoutesPlugin from './user'
 import studentsRoutesPlugin from './students'
+import careersRoutesPlugin from './careers'
 
 export default fp(async function RoutesPlugin (fastify) {
   fastify.register(userRoutesPlugin, { prefix: '/user' })
   fastify.register(studentsRoutesPlugin, { prefix: '/students' })
+  fastify.register(careersRoutesPlugin, { prefix: '/careers' })
 })

--- a/src/service/career/index.ts
+++ b/src/service/career/index.ts
@@ -1,0 +1,39 @@
+import type {
+  Career,
+  CareerServiceI
+} from './types'
+import type { ModuleConstructorParams } from '#src/service/types'
+
+type ConstructorParams = ModuleConstructorParams<
+  'logger'|'connectionManager'
+>
+
+export class CareerService implements CareerServiceI {
+  private readonly logger: ConstructorParams['context']['logger']
+  private readonly connectionManager: ConstructorParams['context']['connectionManager']
+
+  constructor (params: ConstructorParams) {
+    this.logger = params.context.logger
+    this.connectionManager = params.context.connectionManager
+  }
+
+  private get db () {
+    return this.connectionManager.getConnection()
+  }
+
+  private get selectQuery () {
+    const db = this.db
+    return db.table('Careers')
+      .select(
+        db.ref('id').withSchema('Careers'),
+        db.ref('name').withSchema('Careers'),
+        db.ref('slug').withSchema('Careers'),
+        db.ref('createdAt').withSchema('Careers'),
+        db.ref('updatedAt').withSchema('Careers')
+      )
+  }
+
+  async findAll (): Promise<Career[]> {
+    return await this.selectQuery
+  }
+}

--- a/src/service/career/types.d.ts
+++ b/src/service/career/types.d.ts
@@ -1,0 +1,7 @@
+import type { Career } from '#src/types/career'
+
+export { Career } from '#src/types/career'
+
+export interface CareerServiceI {
+  findAll(): Promise<Career[]>
+}

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -8,7 +8,7 @@ import { StudentService } from './student'
 import { BcryptService } from './bcrypt'
 import { TemplateRender } from './template-render/'
 import { ConnectionManager } from '#src/common/bd'
-import { config } from 'process'
+import { CareerService } from './career'
 
 interface GetServicesParams {
   logger: Logger
@@ -49,6 +49,9 @@ export function getServices (params: GetServicesParams): Services {
     context
   })
   context.services.templateRender = lazyLoad((p) => new TemplateRender(p), {
+    context
+  })
+  context.services.careerService = lazyLoad((p) => new CareerService(p), {
     context
   })
   return context.services

--- a/src/service/student/index.ts
+++ b/src/service/student/index.ts
@@ -216,4 +216,12 @@ export class StudentService implements StudentServiceI {
         : undefined
     }
   }
+
+  async findByEmail (email: string): Promise<StudentWithouPassword | null> {
+    const result = await this.selectQuery
+      .where('email', '=', email)
+      .first()
+
+    return result ?? null
+  }
 }

--- a/src/service/student/types.d.ts
+++ b/src/service/student/types.d.ts
@@ -29,6 +29,7 @@ export interface StudentServiceI {
   findAndCount (params: FindAndCountParams): Promise<{ total: number, records: StudentWithCareer[] }>
   updateStudent(id: number, studentData: UpdateStudent): Promise<StudentWithouPassword>
   findById(id: number, opts?: FindByIdOpts): Promise<StudentWithCareer | null>
+  findByEmail(email: string): Promise<StudentWithouPassword | null>
 }
 
 export interface StudentServiceConfigI {

--- a/src/service/types.d.ts
+++ b/src/service/types.d.ts
@@ -3,6 +3,7 @@ import type { UserServiceI } from '#src/service/user/types'
 import type { EmailServiceI } from '#src/service/email/types'
 import type { StudentServiceI } from '#src/service/student/types'
 import type { BcryptServiceI } from '#src/service/bcrypt/types'
+import type { CareerServiceI } from '#src/service/career/types'
 import type { TemplateRenderI } from '#src/service/template-render/types'
 import type { BaseLogger } from 'pino'
 import type { ConnectionManager } from '#src/common/bd'
@@ -16,6 +17,7 @@ export interface Services {
   studentService: () => StudentServiceI
   bcryptService: () => BcryptServiceI
   templateRender: () => TemplateRenderI
+  careerService: () => CareerServiceI
 }
 
 export interface ApplicationContext <T extends (keyof Services | unknown) = keyof Services> {

--- a/test/src/routes/careers.test.ts
+++ b/test/src/routes/careers.test.ts
@@ -1,0 +1,59 @@
+import { describe, beforeAll, afterAll, expect } from 'vitest'
+import { isolatedIt as it } from '#test/utils/isolatedIt'
+import build from '#src/build'
+import { careerFactory } from '#test/utils/factories/career'
+
+describe('Careers API', () => {
+  const app = build()
+
+  beforeAll(async () => {
+    await app.ready()
+  })
+  
+  afterAll(async () => {
+    await app.close()
+  })
+
+  describe('GET /careers', () => {
+    const PATH = '/careers'
+    const METHOD = 'GET'
+    
+    it('Success get all careers returns array of careers', async () => {
+      const careers = await Promise.all([
+        careerFactory.create(),
+        careerFactory.create(),
+        careerFactory.create()
+      ])
+
+      const res = await app.inject({
+        url: PATH,
+        method: METHOD
+      })
+      
+      expect(res.statusCode).toBe(200)
+      const body = res.json()
+      expect(body).toBeInstanceOf(Array)
+      expect(body.length).toBe(3)
+
+      const career = body.find((c: any) => c.id === careers[0].id)
+       expect(career).toBeDefined()
+      expect(career).toHaveProperty('id', careers[0].id)
+      expect(career).toHaveProperty('name', careers[0].name)
+      expect(career).toHaveProperty('slug', careers[0].slug)
+      expect(career).toHaveProperty('createdAt', careers[0].createdAt.toISOString())
+      expect(career).toHaveProperty('updatedAt', careers[0].updatedAt.toISOString())
+    })
+
+   it('Returns empty array when no careers exist', async () => {
+      const res = await app.inject({
+        url: PATH,
+        method: METHOD
+      })
+      
+      expect(res.statusCode).toBe(200)
+      const body = res.json()
+      expect(body).toBeInstanceOf(Array)
+      expect(body.length).toBeGreaterThanOrEqual(0)
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1414,6 +1414,15 @@
   resolved "https://registry.yarnpkg.com/@types/nunjucks/-/nunjucks-3.2.6.tgz#6d6e0363719545df8b9a024279902edf68b2caa9"
   integrity sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==
 
+"@types/pg@^8.15.5":
+  version "8.15.5"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.15.5.tgz#ef43e0f33b62dac95cae2f042888ec7980b30c09"
+  integrity sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==
+  dependencies:
+    "@types/node" "*"
+    pg-protocol "*"
+    pg-types "^2.2.0"
+
 "@types/uuid@^9.0.1":
   version "9.0.8"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
@@ -3725,12 +3734,17 @@ pg-pool@^3.7.0:
   resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.7.0.tgz#d4d3c7ad640f8c6a2245adc369bafde4ebb8cbec"
   integrity sha512-ZOBQForurqh4zZWjrgSwwAtzJ7QiRX0ovFkZr2klsen3Nm0aoh33Ls0fzfv3imeH/nw/O27cjdz5kzYJfeGp/g==
 
+pg-protocol@*:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.10.3.tgz#ac9e4778ad3f84d0c5670583bab976ea0a34f69f"
+  integrity sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==
+
 pg-protocol@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.7.0.tgz#ec037c87c20515372692edac8b63cf4405448a93"
   integrity sha512-hTK/mE36i8fDDhgDFjy6xNOG+LCorxLG3WO17tku+ij6sVHXh1jQUJ8hYAnRhNla4QVD2H8er/FOjc/+EgC6yQ==
 
-pg-types@^2.1.0:
+pg-types@^2.1.0, pg-types@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
   integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==


### PR DESCRIPTION
# Description
Add the endpoint `GET /careers` to fetch the list of all available careers. Also the student API now throws a error 409 when the student invite and creation conflicts with a user already existing in the system.